### PR TITLE
Test and implement Mathwallet for mainnet use

### DIFF
--- a/examples/hrc20/.env
+++ b/examples/hrc20/.env
@@ -1,0 +1,27 @@
+//LOCAL
+//Local uses account one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7 on Shard 0
+LOCAL_PRIVATE_KEY='45e497bd45a9049bcb649016594489ac67b9f052a6cdf5cb74ee2427a60bf25e'
+LOCAL_MNEMONIC='urge clog right example dish drill card maximum mix bachelor section select' 
+LOCAL_0_URL='http://localhost:9500'
+
+//TESTNET
+//Account: one18t4yj4fuutj83uwqckkvxp9gfa0568uc48ggj7
+TESTNET_PRIVATE_KEY='01F903CE0C960FF3A9E68E80FF5FFC344358D80CE1C221C3F9711AF07F83A3BD'
+TESTNET_MNEMONIC='urge clog right example dish drill card maximum mix bachelor section select' 
+
+TESTNET_0_URL='https://api.s0.b.hmny.io'
+TESTNET_1_URL='https://api.s1.b.hmny.io'
+
+//MAINNET
+//Please replace MAINNET_PRIVATE_KEY and MAINNET_MNEMONIC with your own!
+//Account: 'one1vqpf94xctamtzatlyjmerjtx7gp93hyzekyh87'
+MAINNET_PRIVATE_KEY='0x98aac0f92593d4e9189de6db67e71434c8c6599c0fed358cdc4ced8e26b92d25'
+MAINNET_MNEMONIC='share ten economy toast disorder moon path matter crew moment poet tribe'
+MAINNET_0_URL='https://api.s0.t.hmny.io'
+
+GAS_LIMIT=3321900
+GAS_PRICE=1000000000
+
+ENV='mainnet'
+network=2
+net=1

--- a/examples/hrc20/config.js
+++ b/examples/hrc20/config.js
@@ -1,6 +1,10 @@
+require('dotenv').config()
+
 export default {
-    ENV: 'local',
-    network: 0, // 0 local, 1 testnet, 2 mainnet
-    localUrl: `ws://localhost:9800`,
-    
+    ENV: process.env.ENV,
+    network: process.env.network, // 0 local, 1 testnet, 2 mainnet
+    net: process.env.net, //TODO: change name
+    localUrl: process.env.LOCAL_0_URL,
+    testnetUrl: process.env.TESTNET_0_URL,
+    mainnetUrl: process.env.MAINNET_0_URL,
 }

--- a/examples/hrc20/deploy.sh
+++ b/examples/hrc20/deploy.sh
@@ -1,4 +1,4 @@
-truffle migrate --reset --network local
+truffle migrate --reset --network ${1} 
 
 rm -rf ./src/build/*
 cp -r ./build/* ./src/build/

--- a/examples/hrc20/package.json
+++ b/examples/hrc20/package.json
@@ -21,7 +21,7 @@
     "sass": "^1.23.7"
   },
   "scripts": {
-    "start": "pkill node; REACT_APP_ENV=local parcel ./src/index.html --open > output.log &"
+    "start": "pkill node; parcel ./src/index.html --open > output.log &"
   },
   "browserslist": [
     "last 2 Chrome versions"

--- a/examples/hrc20/src/components/Form/Form.js
+++ b/examples/hrc20/src/components/Form/Form.js
@@ -46,7 +46,8 @@ export default function Form(props) {
                             onChange={handleInputChange}
                         />
                         {
-                            addresses.filter((a) => a !== active[addressType]).map((a) => (
+                            //addresses.filter((a) => a !== active[addressType]).map((a) => (
+                            addresses.map((a) => (
                                 <p
                                     name="address"
                                     key={a}

--- a/examples/hrc20/src/redux/hrc20.js
+++ b/examples/hrc20/src/redux/hrc20.js
@@ -1,5 +1,5 @@
 import { UPDATE, reducer } from '../util/redux-util'
-import { getContractInstance } from '../util/hmy-util'
+import { getContract } from '../util/hmy-util'
 import HarmonyMintable from '../build/contracts/HarmonyMintable.json'
 import {getBalances, updateProcessing} from './harmony'
 
@@ -17,13 +17,7 @@ export const hrc20State = ({ hrc20Reducer: { ...keys } }) => {
 export const transferHRC = ({ amount, address }) => async (dispatch, getState) => {
     dispatch(updateProcessing(true))
     dispatch({ type: UPDATE })
-    const { hmy, hmyExt, active } = getState().harmonyReducer
-    if (!hmy) {
-        console.log('call loadContracts first')
-        return
-    }
-    console.log(amount, address)
-    const contract = await getContractInstance(active.isExt ? hmyExt : hmy, HarmonyMintable)
+    const { hmy, contract, active } = await getContract(getState().harmonyReducer, HarmonyMintable)
     const tx = contract.methods.transfer(address, new hmy.utils.Unit(amount).asEther().toWei()).send({
         from: active.address,
         gasLimit: '1000000',
@@ -40,15 +34,10 @@ export const transferHRC = ({ amount, address }) => async (dispatch, getState) =
 }
 
 export const getBalanceHRC = (account) => async (dispatch, getState) => {
-    const { hmy } = getState().harmonyReducer
-    if (!hmy) {
-        console.log('call loadContracts first')
-        return
-    }
-    const contract = await getContractInstance(hmy, HarmonyMintable)
+    const { hmy, contract } = await getContract(getState().harmonyReducer, HarmonyMintable)
     const balance = await contract.methods.balanceOf(account.address).call({
-        gasLimit: '210000',
-        gasPrice: '100000',
+        gasLimit: '2100000',
+        gasPrice: '1000000000',
     })
     if (balance === null) {
         console.log('contracts not deployed, use ./deploy.sh')

--- a/examples/hrc20/src/util/hmy-util.js
+++ b/examples/hrc20/src/util/hmy-util.js
@@ -1,8 +1,21 @@
+import config from '../../config'
+const { net } = config
 
 
-
+//TODO: naming
+export const getContract = (state, artifact) => {
+    const { hmy, hmyExt, active } = state
+    if (!hmy) {
+        console.log('call loadContracts first')
+        return
+    }
+    const harmony = active && active.isExt ? hmyExt : hmy
+    const contract = getContractInstance(harmony, artifact)
+    return { hmy, contract, active }
+}
 export const getContractInstance = (hmy, artifact) => {
-    return hmy.contracts.createContract(artifact.abi, artifact.networks[2].address)
+    const contract = hmy.contracts.createContract(artifact.abi, artifact.networks[net].address)
+    return contract
 }
 export const getExtAccount = async (hmyExt) => {
     const account = await hmyExt.wallet.getAccount().catch((err) => {
@@ -14,7 +27,6 @@ export const getExtAccount = async (hmyExt) => {
     return account
 }
 export const waitForInjected = (sec) => new Promise((resolve) => {
-    console.log(sec)
     const max = sec * 1000 / 250
     let tries = 0
     const check = () => {


### PR DESCRIPTION
- Implements a config to allow switching between a local instance of the Harmony blockchain, the testnet, and the mainnet.
- Adds a wrapper function for contracts to facilitate switching between a hard-coded wallet for localnet and a Mathwallet powered system for testnet and mainnet.