### PR TITLE
Fix swapped addresses in truffle example, fix contract name error

### DIFF
--- a/examples/truffle/contracts/HarmonyERC20.sol
+++ b/examples/truffle/contracts/HarmonyERC20.sol
@@ -4,7 +4,7 @@ import "openzeppelin-solidity/contracts/token/ERC20/ERC20Detailed.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20Mintable.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 
-contract HarmonyMintable is ERC20, ERC20Detailed, ERC20Mintable {
+contract HarmonyERC20 is ERC20, ERC20Detailed, ERC20Mintable {
       constructor(string memory _name, string memory _symbols, uint8 _decimals, uint256 _amount) 
         ERC20Detailed(_name, _symbols, _decimals)
         public {

--- a/examples/truffle/hmy-utils.js
+++ b/examples/truffle/hmy-utils.js
@@ -1,0 +1,7 @@
+const { Harmony } = require("@harmony-js/core")
+const { ChainType, ChainID } = require("@harmony-js/utils")
+const hmy = new Harmony('http://localhost:9500/', {chainType: ChainType.Harmony, chainId: ChainID.HmyLocal})
+
+//helper function to convert bech32 addresses to Hexadecimal
+exports.toHex = (bech32Addr) => hmy.crypto.getAddress(bech32Addr).basicHex;
+exports.toBech32 = (HexAddr) => hmy.crypto.getAddress(HexAddr).bech32;

--- a/examples/truffle/mint_transfer.js
+++ b/examples/truffle/mint_transfer.js
@@ -1,11 +1,12 @@
 var HarmonyERC20 = artifacts.require("HarmonyERC20");
+const { toHex, toBech32 } = require("./hmy-utils")
 
 //mint amount address
-const myAddress =   "0x3aea49553Ce2E478f1c0c5ACC304a84F5F4d1f98";
+const myAddress = "one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7";
 
 //test account address, keys under
 //https://github.com/harmony-one/harmony/blob/master/.hmy/keystore/one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7.key
-const testAccount = "0x7c41e0668b551f4f902cfaec05b5bdca68b124ce";
+let testAccount = "one18t4yj4fuutj83uwqckkvxp9gfa0568uc48ggj7";
 
 const transferAmount = 20000;
 
@@ -17,12 +18,11 @@ module.exports = function() {
         let decimals = await instance.decimals();
         
         console.log('calling transfer')
-        const tx = await instance.transfer(testAccount, transferAmount);
-        // console.log(tx)
-        let testAccBalance = await instance.balanceOf(testAccount);
-        let myAddrBalance = await instance.balanceOf(myAddress);
+        const tx = await instance.transfer(toHex(testAccount), transferAmount);
+        let testAccBalance = await instance.balanceOf(toHex(testAccount));
+        let myAddrBalance = await instance.balanceOf(toHex(myAddress));
 
-        console.log("HarmonyERC20 is deployed at address " + instance.address);
+        console.log("HarmonyERC20 is deployed at address " + toBech32(instance.address));
         console.log("Harmony ERC20 Information: Name    : " + name);
         console.log("Harmony ERC20 Information: Decimals: " + decimals);
         console.log("Harmony ERC20 Information: Total   : " + total.toString());

--- a/examples/truffle/show_balance.js
+++ b/examples/truffle/show_balance.js
@@ -1,13 +1,14 @@
 var HarmonyERC20 = artifacts.require("HarmonyERC20");
+const { toHex, toBech32 } = require("./hmy-utils")
 
 //mint amount address
 
-let myAddress =   "0x3aea49553Ce2E478f1c0c5ACC304a84F5F4d1f98";
+let testAccount = "one18t4yj4fuutj83uwqckkvxp9gfa0568uc48ggj7";
 // myAddress = "0xea877e7412c313cd177959600e655f8ba8c28b40";
 
 //test account address, keys under
 //https://github.com/harmony-one/harmony/blob/master/.hmy/keystore/one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7.key
-const testAccount = "0x7c41e0668b551f4f902cfaec05b5bdca68b124ce";
+const myAddress = "one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7";
 
 const transferAmount = 2000000;
 
@@ -17,10 +18,10 @@ module.exports = function() {
         let name = await instance.name();
         let total = await instance.totalSupply();
         let decimals = await instance.decimals();
-        let mybalance = await instance.balanceOf(myAddress);
-        let testAccBalance = await instance.balanceOf(testAccount);
+        let mybalance = await instance.balanceOf(toHex(myAddress));
+        let testAccBalance = await instance.balanceOf(toHex(testAccount));
 
-        console.log("HarmonyERC20 is deployed at address " + instance.address);
+        console.log("HarmonyERC20 is deployed at address " + toBech32(instance.address));
         console.log("Harmony ERC20 Information: Name    : " + name);
         console.log("Harmony ERC20 Information: Decimals: " + decimals);
         console.log("Harmony ERC20 Information: Total   : " + total.toString());


### PR DESCRIPTION
#### In examples/truffle : ####
There was a naming error for the HarmonyERC20.sol contract. 
In mint-transfer.js, the receiver was accidentally set as the minter/sender, so no funds got transferred.
Added a hmy-utils.js file exporting functions to convert between bech32 and hexadecimal addresses.