### PR TITLE
Remove HarmonyMintable references in config

### DIFF
--- a/examples/node-hrc20/config.js
+++ b/examples/node-hrc20/config.js
@@ -1,7 +1,7 @@
 require('dotenv').config()
 
 let network, net, url, privateKey
-let HRC20Crowdsale, HarmonyMintable, Migrations 
+let HRC20Crowdsale, HRC20, Migrations 
 
 switch(process.env.ENV){
     case 'local': {
@@ -17,7 +17,7 @@ switch(process.env.ENV){
         url = process.env.TESTNET_0_URL
         privateKey = process.env.TESTNET_PRIVATE_KEY
         HRC20Crowdsale = process.env.TESTNET_HRC20CROWDSALE
-        HarmonyMintable = process.env.TESTNET_HARMONYMINTABLE
+        HRC20 = process.env.TESTNET_HRC20
         Migrations = process.env.TESTNET_MIGRATIONS
         break;
     }
@@ -27,7 +27,7 @@ switch(process.env.ENV){
         url = process.env.MAINNET_0_URL
         privateKey = process.env.MAINNET_PRIVATE_KEY
         HRC20Crowdsale = process.env.MAINNET_HRC20CROWDSALE
-        HarmonyMintable = process.env.MAINNET_HARMONYMINTABLE
+        HRC20 = process.env.MAINNET_HRC20
         Migrations = process.env.MAINNET_MIGRATIONS
         break;
     }
@@ -42,6 +42,6 @@ module.exports = {
     url,   
     //use these if not deploying contract or targeting a different deployment on (same or ) different network
     HRC20Crowdsale: HRC20Crowdsale,
-    HarmonyMintable: HarmonyMintable,
+    HRC20: HRC20,
     Migrations: Migrations,
 }

--- a/examples/node-hrc20/package.json
+++ b/examples/node-hrc20/package.json
@@ -12,6 +12,6 @@
   },
   "scripts": {
     "start": "node src/app.js",
-    "deploy": "truffle migrate --reset --network ${1}"
+    "deploy": "truffle migrate --reset --network "
   }
 }


### PR DESCRIPTION
Also remove bash script artifact from npm script

## Issue
HarmonyMintable references cause errors when using contract address instead of deploying a new contract.