### PR TITLE
add queue to faucet, validate faucet use

### DIFF
--- a/examples/node-faucet/config.js
+++ b/examples/node-faucet/config.js
@@ -1,6 +1,7 @@
-// require('dotenv').config()
+require('dotenv').config()
 
 let network, net, url, privateKey, Faucet
+const ONE = 1000000000000000000 // 1 ONE in atto
 
 switch(process.env.ENV){
     case 'local': {
@@ -38,5 +39,7 @@ module.exports = {
     url,
     GAS_LIMIT: process.env.GAS_LIMIT,
     GAS_PRICE: process.env.GAS_PRICE,
+    timeLimit: process.env.TIME_LIMIT ? parseInt(process.env.TIME_LIMIT) : 3600000, // 1 Hour
+    txRate: process.env.TX_RATE ? parseInt(process.env.TX_RATE) : 11000 * ONE, //11000 ONE
     Faucet
 }

--- a/examples/node-faucet/package-lock.json
+++ b/examples/node-faucet/package-lock.json
@@ -140,6 +140,11 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
+    "async-mutex": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.1.4.tgz",
+      "integrity": "sha512-zVWTmAnxxHaeB2B1te84oecI8zTDJ/8G49aVBblRX6be0oq6pAybNcUSxwfgVOmOjSCvN4aYZAqwtyNI8e1YGw=="
+    },
     "bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",

--- a/examples/node-faucet/package.json
+++ b/examples/node-faucet/package.json
@@ -8,6 +8,7 @@
     "@openzeppelin/contracts": "^2.5.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
+    "sha.js": "^2.4.11",
     "tslib": "^1.10.0"
   },
   "scripts": {

--- a/examples/node-faucet/package.json
+++ b/examples/node-faucet/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@harmony-js/core": "^0.1.36",
     "@openzeppelin/contracts": "^2.5.0",
+    "async-mutex": "^0.1.4",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "sha.js": "^2.4.11",

--- a/examples/node-faucet/src/index.html
+++ b/examples/node-faucet/src/index.html
@@ -14,12 +14,11 @@
         <h1>ONE Faucet</h1>
     </header>
     <div id="faucet">
-        <p>Enter your ONE address and click fund.<br />We'll send a transaction to the Harmony blockchain and let you
-            know when it's confirmed.</p>
+        <p>Enter your ONE address and click fund.<br />We'll send a transaction to the Harmony blockchain</p>
         <input id="input" placeholder="ONE Address" type="text" />
         <br>
         <button id="submit">Fund</button>
-        <p id="loading">Waiting for confirmation...</p>
+        <p id="loading">Queuing...</p>
         <p id="output"></p>
     </div>
     <script>
@@ -35,10 +34,9 @@
                     .then((res) => {
                         qs('#loading').style.display = 'none'
                         if (res.success === true) {
-                            qs('#output').innerHTML = '<h4>Balances</h4>' +
-                                res.balances.map((b) => `<p>Shard ${b.shard}: ${b.balance}</p>`).join('')
+                            qs('#output').innerHTML = '<h4>Queued!</h4>' + res.message
                         } else {
-                            qs('#output').innerHTML = '<p>An error occurred. Please try again!</p>'
+                            qs('#output').innerHTML = '<h4>An error occurred!</h4>' + res.message
                         }
                     })
             }


### PR DESCRIPTION
## Procedure
1. Implement a queue to add pending transactions to, instead of sending transactions as soon as the `/fund` endpoint is called.
2. Use setInterval to send a pending transaction to the chain every ~15 seconds
3. Implement checks (calls from same ip/user-agent, same ip within time limit) and reject pushing to queue if checks fail.