### PR TITLE
Add Dockerfile and docker-compose to contractless faucet

### DIFF
--- a/examples/node-faucet-no-contract/Dockerfile
+++ b/examples/node-faucet-no-contract/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:13
+
+RUN mkdir -p /usr/src/faucet
+
+WORKDIR /usr/src/faucet
+
+COPY package.json /usr/src/faucet
+
+RUN npm i
+
+ARG invalidate=0
+COPY ./public /usr/src/faucet/public
+COPY ./src /usr/src/faucet/src
+COPY ./config.js /usr/src/faucet
+COPY ./cleandb.js /usr/src/faucet
+
+EXPOSE 3000
+
+CMD ["npm", "start"]

--- a/examples/node-faucet-no-contract/docker-compose.yml
+++ b/examples/node-faucet-no-contract/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3"
+services:
+    faucet:
+        container_name: faucet
+        restart: always
+        build: .
+        ports:
+            - "3000:3000"
+        environment:
+            ENV: ${ENV}
+            TESTNET_CHAIN_ID: ${TESTNET_CHAIN_ID}
+            TESTNET_0_URL: ${TESTNET_0_URL}
+            TESTNET_PRIVATE_KEY: ${TESTNET_PRIVATE_KEY}
+            GAS_LIMIT: ${GAS_LIMIT}
+            GAS_PRICE: ${GAS_PRICE}
+            TIME_LIMIT: ${TIME_LIMIT}
+            TX_RATE: ${TX_RATE}
+            RECAPTCHA_SECRET: ${RECAPTCHA_SECRET}
+            PROXY: ${PROXY}
+            USAGE_LIMIT: ${USAGE_LIMIT}


### PR DESCRIPTION
## Notes
* ``docker-compose.yml``  will be built out to use mongodb after refactor